### PR TITLE
Fix TypeError: unhashable type: 'list'.

### DIFF
--- a/rally_openstack/verification/tempest/context.py
+++ b/rally_openstack/verification/tempest/context.py
@@ -143,12 +143,14 @@ class TempestContext(context.VerifierContext):
 
     def _create_tempest_roles(self):
         keystoneclient = self.clients.verified_keystone()
-        roles = {}
+        roles = []
 
         if "swift" in self.enabled_services:
-            roles[conf.CONF.openstack.swift_operator_role] = conf.CONF.openstack.swift_reseller_admin_role
+            roles.append(conf.CONF.openstack.swift_operator_role)
+            roles.append(conf.CONF.openstack.swift_reseller_admin_role)
         if "heat" in self.enabled_services:
-            roles[conf.CONF.openstack.heat_stack_owner_role] = conf.CONF.openstack.heat_stack_user_role
+            roles.append(conf.CONF.openstack.heat_stack_owner_role)
+            roles.append(conf.CONF.openstack.heat_stack_user_role)
 
         existing_roles = set(role.name for role in keystoneclient.roles.list())
 

--- a/rally_openstack/verification/tempest/context.py
+++ b/rally_openstack/verification/tempest/context.py
@@ -143,12 +143,12 @@ class TempestContext(context.VerifierContext):
 
     def _create_tempest_roles(self):
         keystoneclient = self.clients.verified_keystone()
-        roles = []
+        roles = {}
 
         if "swift" in self.enabled_services:
-            roles.append([conf.CONF.openstack.swift_operator_role, conf.CONF.openstack.swift_reseller_admin_role])
+            roles[conf.CONF.openstack.swift_operator_role] = conf.CONF.openstack.swift_reseller_admin_role
         if "heat" in self.enabled_services:
-            roles.append([conf.CONF.openstack.heat_stack_owner_role, conf.CONF.openstack.heat_stack_user_role])
+            roles[conf.CONF.openstack.heat_stack_owner_role] = conf.CONF.openstack.heat_stack_user_role
 
         existing_roles = set(role.name for role in keystoneclient.roles.list())
 


### PR DESCRIPTION
roles = [] leads to TypeError: unhashable type: 'list' if one set swift = True in the service_available section of the tempest configuration.

